### PR TITLE
Adds ability to play a track within a subfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Module specification and pins reference is [here](https://wiki.dfrobot.com/DFPla
 Playback control:
 ```python
 play(track_id) # track_id, 'next' or 'prev'
+play(track_id, folder)  # track_id in folder (both integers)
 pause()
 resume()
 loop_track(track_id)
@@ -62,6 +63,7 @@ music.fadeout(2000)
 
 music.play(2)
 music.loop()
+music.play(3, 2)  # Plays track 3 in folder 2
 sleep(20)
 
 music.module_sleep()

--- a/dfplayermini.py
+++ b/dfplayermini.py
@@ -16,9 +16,9 @@ class Player:
         self._max_volume = 15
         self._fadeout_speed = 0
 
-    def cmd(self, command, parameter=0x00):
+    def cmd(self, command, parameter=0x00, highparameter=0x00):
         query = bytes([0x7e, 0xFF, 0x06, command,
-                       0x00, 0x00, parameter, 0xEF])
+                       0x00, highparameter, parameter, 0xEF])
         self.uart.write(query)
 
     def _fade_out_process(self, timer):
@@ -34,8 +34,12 @@ class Player:
 
     # playback
 
-    def play(self, track_id=False):
-        if not track_id:
+    def play(self, track_id=False, folder=False):
+        if folder and track_id:
+            self.cmd(0x0F, track_id, highparameter=folder)
+            # NB cmd 0X0F requires folder and track_id params.
+            # 'High' byte and 'Low' byte in the DFRobot C code. 
+        elif not track_id:
             self.resume()
         elif track_id == 'next':
             self.cmd(0x01)


### PR DESCRIPTION
Hi- Great library for the DFPlayerMini.  I had been looking for something easier to work with than the C for the Arduino!
This PR adds the ability to choose which folder to play from within the .play() method.

N.B. The folderplay command is 0x0F and requires a 'high' byte before the 'low parameter' byte - I use 'highparameter' as the DF Robot C code converts these two bytes into a single uint16 with the folder being the high byte and track_id the low byte.
It therefore needed some addition to the .cmd() method but this should not interfere with any existing code.

I also updated the readme to reflect the changes.